### PR TITLE
#34 manage ssl settings and add spec tests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,11 @@ class etherpad (
   # Users
   Optional[Hash] $users = undef,
 
+  # Ssl
+  Enum['enable','disable'] $ssl  = 'disable',
+  Stdlib::Absolutepath $ssl_key  = '/etc/ssl/epad/epl-server.key',
+  Stdlib::Absolutepath $ssl_cert = '/etc/ssl/epad/epl-server.crt',
+
   # Logging
   Boolean $logconfig_file                        = false,
   Optional[String] $logconfig_file_filename      = undef,

--- a/spec/classes/etherpad_spec.rb
+++ b/spec/classes/etherpad_spec.rb
@@ -15,7 +15,7 @@ describe 'etherpad' do
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r|^\s*"users": {$|) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{ldapauth}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{ep_button_link}) }
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(/^"ssl" :/) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{\"ssl" :}) }
           it { is_expected.to contain_service('etherpad') }
           it { is_expected.to contain_user('etherpad') }
           it { is_expected.to contain_group('etherpad') }
@@ -32,7 +32,7 @@ describe 'etherpad' do
         end
 
         context 'etherpad class with button_link set and ssl enabled' do
-          let (:params) do
+          let(:params) do
             {
               button_link: {
                 'text'   => 'Link Button',
@@ -45,13 +45,14 @@ describe 'etherpad' do
               ssl_cert: '/yourpath/etherpad.crt'
             }
           end
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/\"ssl\" : /) }
+
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"ssl\" :}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"key\"  : \"/yourpath/etherpad.key\"}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"cert\" : \"/yourpath/etherpad.crt\"}) }
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/^\s*"ep_button_link": {$/) }
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/^\s*"text": "Link Button",$/) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r|^\s*"ep_button_link": {$|) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"text": "Link Button",$}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"link": "https://example\.com/pad-lister",$}) }
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/^\s*"before": "li\[data-key='showTimeSlider'\]"$/) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"before": "li\[data-key='showTimeSlider'\]"$}) }
         end
       end
     end
@@ -100,7 +101,7 @@ describe 'etherpad' do
             }
           end
 
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r|^\s*"ep_button_link": {$|) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r/^\s*"ep_button_link": {$/) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"text": "Link Button",$}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"link": "http://example\.com/pad-lister",$}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"before": "li\[data-key='showTimeSlider'\]"$}) }
@@ -183,7 +184,7 @@ describe 'etherpad' do
             }
           end
 
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/\"ssl\" : /) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"ssl\" :}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"key\"  : \"/yourpath/etherpad.key\"}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"cert\" : \"/yourpath/etherpad.crt\"}) }
           it { is_expected.to compile.with_all_deps }
@@ -267,7 +268,7 @@ describe 'etherpad' do
             }
           end
 
-          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(/\"ssl\" : /) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{\"ssl\" :}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{\"key\"  : \"/yourpath/etherpad.key\"}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{\"cert\" : \"/yourpath/etherpad.crt\"}) }
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/etherpad_spec.rb
+++ b/spec/classes/etherpad_spec.rb
@@ -15,9 +15,43 @@ describe 'etherpad' do
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r|^\s*"users": {$|) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{ldapauth}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{ep_button_link}) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(/^"ssl" :/) }
           it { is_expected.to contain_service('etherpad') }
           it { is_expected.to contain_user('etherpad') }
           it { is_expected.to contain_group('etherpad') }
+        end
+      end
+    end
+  end
+
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        context 'etherpad class with button_link set and ssl enabled' do
+          let (:params) do
+            {
+              button_link: {
+                'text'   => 'Link Button',
+                'link'   => 'https://example.com/pad-lister',
+                'before' => "li[data-key='showTimeSlider']"
+              },
+              # Ssl
+              ssl: 'enable',
+              ssl_key: '/yourpath/etherpad.key',
+              ssl_cert: '/yourpath/etherpad.crt'
+            }
+          end
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/\"ssl\" : /) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"key\"  : \"/yourpath/etherpad.key\"}) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"cert\" : \"/yourpath/etherpad.crt\"}) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/^\s*"ep_button_link": {$/) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/^\s*"text": "Link Button",$/) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"link": "https://example\.com/pad-lister",$}) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/^\s*"before": "li\[data-key='showTimeSlider'\]"$/) }
         end
       end
     end
@@ -70,6 +104,90 @@ describe 'etherpad' do
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"text": "Link Button",$}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"link": "http://example\.com/pad-lister",$}) }
           it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{^\s*"before": "li\[data-key='showTimeSlider'\]"$}) }
+        end
+
+        context 'etherpad class with all parameters set and ssl enabled' do
+          let(:params) do
+            {
+              ensure: 'present',
+              service_name: 'etherpad',
+              service_ensure: 'running',
+              service_provider: facts[:service_provider],
+              manage_user: true,
+              manage_abiword: false,
+              abiword_path: '/usr/bin/abiword',
+              manage_tidy: false,
+              tidy_path: '/usr/bin/tidy',
+              user: 'etherpad',
+              group: 'etherpad',
+              root_dir: '/opt/etherpad',
+              source: 'https://github.com/ether/etherpad-lite.git',
+
+              # Db
+              database_type: 'dirty',
+              database_host: 'localhost',
+              database_user: 'etherpad',
+              database_name: 'etherpad',
+              database_password: 'etherpad',
+
+              # Network
+              ip: '*',
+              port: 9001,
+              trust_proxy: false,
+
+              # Performance
+              max_age: 21_600,
+              minify: true,
+
+              # Config
+              button_link: {
+                'text'   => 'Link Button',
+                'link'   => 'http://example.com/pad-lister',
+                'before' => "li[data-key='showTimeSlider']"
+              },
+              ldapauth: {
+                'url' => 'ldap://ldap.foobar.com',
+                'groupAttributeIsDN' => true
+              },
+              require_session: false,
+              edit_only: false,
+              require_authentication: false,
+              require_authorization: false,
+              pad_title: :undef,
+              default_pad_text: 'Welcome to etherpad!',
+
+              # Users
+              'users' => {
+                'admin' => {
+                  'password' => 's3cr3t',
+                  'is_admin' => true
+                },
+                'user' => {
+                  'password' => 'secret',
+                  'is_admin' => false
+                }
+              },
+
+              # Ssl
+              ssl: 'enable',
+              ssl_key: '/yourpath/etherpad.key',
+              ssl_cert: '/yourpath/etherpad.crt',
+
+              # Logging
+              logconfig_file: true,
+              logconfig_file_filename: '/var/log/etherpad.log',
+              logconfig_file_max_log_size: 1024,
+              logconfig_file_backups: 3,
+              logconfig_file_category: 'etherpad'
+
+            }
+          end
+
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(/\"ssl\" : /) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"key\"  : \"/yourpath/etherpad.key\"}) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').with_content(%r{\"cert\" : \"/yourpath/etherpad.crt\"}) }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/var/log/etherpad.log') }
         end
 
         context 'etherpad class with all parameters set' do
@@ -134,6 +252,11 @@ describe 'etherpad' do
                 }
               },
 
+              # Ssl
+              ssl: 'disable',
+              ssl_key: '/yourpath/foobar/etherpad.key',
+              ssl_cert: '/yourpath/foobar/etherpad.crt',
+
               # Logging
               logconfig_file: true,
               logconfig_file_filename: '/var/log/etherpad.log',
@@ -144,6 +267,9 @@ describe 'etherpad' do
             }
           end
 
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(/\"ssl\" : /) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{\"key\"  : \"/yourpath/etherpad.key\"}) }
+          it { is_expected.to contain_file('/opt/etherpad/settings.json').without_content(%r{\"cert\" : \"/yourpath/etherpad.crt\"}) }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_file('/var/log/etherpad.log') }
         end

--- a/templates/settings.json.epp
+++ b/templates/settings.json.epp
@@ -22,20 +22,17 @@
   <%- } -%>
   "port" : <%= $etherpad::port -%>,
 
-  /*
   // Node native SSL support
-  // this is disabled by default
-  //
   // make sure to have the minimum and correct file access permissions set
   // so that the Etherpad server can access them
-
+  <%- if $etherpad::ssl == 'enable' { -%>
   "ssl" : {
-            "key"  : "/path-to-your/epl-server.key",
-            "cert" : "/path-to-your/epl-server.crt",
-            "ca": ["/path-to-your/epl-intermediate-cert1.crt", "/path-to-your/epl-intermediate-cert2.crt"]
+          "key"  : "<%= $etherpad::ssl_key -%>",
+          "cert" : "<%= $etherpad::ssl_cert -%>"
           },
-
-  */
+  <%- } else { -%>
+  // SSL module is not enable by default
+  <%-  } -%>
 
   //The Type of the database. You can choose between dirty, postgres, sqlite and mysql
   //You shouldn't use "dirty" for for anything else than testing or development

--- a/templates/settings.json.epp
+++ b/templates/settings.json.epp
@@ -31,7 +31,7 @@
           "cert" : "<%= $etherpad::ssl_cert -%>"
           },
   <%- } else { -%>
-  // SSL module is not enable by default
+  // SSL module is not enabled by default
   <%-  } -%>
 
   //The Type of the database. You can choose between dirty, postgres, sqlite and mysql


### PR DESCRIPTION
Work about #34 to manage ssl settings 

* Add parameters $ssl and $ssl_key and $ssl_cert to `init.pp` and template.
* Add relatives spec tests.
