### PR TITLE
Add dependencies for systemd service file

### DIFF
--- a/templates/service/systemd.epp
+++ b/templates/service/systemd.epp
@@ -1,5 +1,7 @@
 [Unit]
 Description="Etherpad lite"
+After=network.target
+Requires=network.target
 
 [Service]
 User=<%= $etherpad::user %>
@@ -7,3 +9,6 @@ Group=<%= $etherpad::group %>
 
 WorkingDirectory=<%= $etherpad::root_dir %>
 ExecStart=<%= $etherpad::root_dir -%>/bin/run.sh 
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
With current systemd service file for etherpad systemctl throws error:

systemctl enable etherpad
Synchronizing state of etherpad.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable etherpad
The unit files have no installation config (WantedBy, RequiredBy, Also, Alias
settings in the [Install] section, and DefaultInstance for template units).
This means they are not meant to be enabled using systemctl.
Possible reasons for having this kind of units are:
1) A unit may be statically enabled by being symlinked from another unit's
   .wants/ or .requires/ directory.
2) A unit's purpose may be to act as a helper for some other unit which has
   a requirement dependency on it.
3) A unit may be started when needed via activation (socket, path, timer,
   D-Bus, udev, scripted systemctl call, ...).
4) In case of template units, the unit is meant to be enabled with some
   instance name specified.