### PR TITLE
update stdlib min version to 4.17.0 (with service_provider fact)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.17.0 < 6.0.0"
     },
     {
       "name": "puppetlabs-vcsrepo",


### PR DESCRIPTION

#### Pull Request (PR) description

The fact `service_provider` provised by `stdlib >= 4.17.0` is used by module. 

Needed to update `metadata.json` accordingly.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
