### PR TITLE
Add use_default_ldapauth option to allow skip merging of default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ see below.
 |-----|--------|
 |Boolean|`false`|
 
+#### use_default_ldapauth
+
+Merge default ldapauth options to final config of ep_ldapauth plugin. If set to 'false' it can be used to omit default searchDN and searchPWD for anonymous ldap access.
+
+|Type |Default |
+|-----|--------|
+|Boolean|`true`|
+
 #### plugins_list
 
 Manage etherpad's plugins.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class etherpad (
   Boolean $edit_only                = false,
   Boolean $require_authentication   = false,
   Boolean $require_authorization    = false,
+  Boolean $use_default_ldapauth     = true,
   Optional[String]  $pad_title      = undef,
   String $default_pad_text          = 'Welcome to etherpad!',
 

--- a/manifests/plugins/ep_ldapauth.pp
+++ b/manifests/plugins/ep_ldapauth.pp
@@ -15,10 +15,16 @@ class etherpad::plugins::ep_ldapauth {
     groupSearch          => '(&(cn=admin)(objectClass=groupOfNames))',
     anonymousReadonly    => false,
   }
-  if $etherpad::ldapauth == {} {
-    fail('You are using the default LDAP configuration. You cannot be able to connect on any LDAP with this configuration. Please add/configure the parameter `ldapauth` to use your own parameters and check the documentation.')
+
+  if $etherpad::use_default_ldapauth {
+    if $etherpad::ldapauth == {} {
+      fail('You are using the default LDAP configuration. You cannot be able to connect on any LDAP with this configuration. Please add/configure the parameter `ldapauth` to use your own parameters and check the documentation.')
+    }
+    $_real_ldapauth_options = merge($default_ldapauth_options, $etherpad::ldapauth)
+  } else {
+    $_real_ldapauth_options = $etherpad::ldapauth
   }
-  $_real_ldapauth_options = merge($default_ldapauth_options, $etherpad::ldapauth)
+
   concat::fragment { 'ep_ldapauth':
     target  => "${etherpad::root_dir}/settings.json",
     content => epp("${module_name}/plugins/ep_ldapauth.epp"),

--- a/spec/classes/etherpad_spec.rb
+++ b/spec/classes/etherpad_spec.rb
@@ -217,6 +217,37 @@ describe 'etherpad' do
           it { is_expected.to contain_concat_fragment('settings-second.json.epp').without_content(%r{test_user}) }
         end
 
+        context 'etherpad class without default ldapauth' do
+          let(:params) do
+            {
+              use_default_ldapauth: false,
+              plugins_list: {
+                'ep_ldapauth' => true
+              },
+              ldapauth: {
+                'url'                => 'ldap://ldap.foobar.com',
+                'accountBase'        => 'o=staff,o=foo,dc=bar,dc=com',
+                'groupAttributeIsDN' => false
+              },
+              users: {
+                'test_user' => {
+                  'password' => 's3cr3t',
+                  'is_admin' => true
+                }
+              }
+            }
+          end
+
+          it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r|^\s*"users": {$|) }
+          it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r|^\s*"ldapauth": {$|) }
+          it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r{^\s*"url": "ldap:\/\/ldap.foobar.com",$}) }
+          it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r{^\s*"accountBase": "o=staff,o=foo,dc=bar,dc=com",$}) }
+          it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r{^\s*"groupAttributeIsDN": false$}) }
+          it { is_expected.to contain_concat_fragment('settings-second.json.epp').without_content(%r{test_user}) }
+          it { is_expected.to contain_concat_fragment('settings-second.json.epp').without_content(%r{searchPWD}) }
+          it { is_expected.to contain_concat_fragment('settings-second.json.epp').without_content(%r{searchDN}) }
+        end
+
         context 'etherpad class with button_link set' do
           let(:params) do
             {
@@ -396,6 +427,7 @@ describe 'etherpad' do
                 'url'                => 'ldap://ldap.foobar.com',
                 'groupAttributeIsDN' => true
               },
+              use_default_ldapauth: false,
               require_session: false,
               edit_only: false,
               require_authentication: false,


### PR DESCRIPTION
#### Pull Request (PR) description
Add option 'no_default_ldapauth' to allow no merging of default ldapauth settings. 
The option can be used for instance to omit searchDN and searchPWD settings
to enable anonymous LDAP access.
