### PR TITLE
ep_mypads does not use ep_ldapauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ List of all plugins is avalable at https://static.etherpad.org/plugins.html
 
 If the plugin is not supported, it will be installed but whitout configuration.
 
-Exemple :
+Examples :
 
 ```puppet
 class { 'etherpad':
@@ -378,7 +378,35 @@ class { 'etherpad':
   },
 }
 ```
+
 In this case `ep_button_link` will be installed with the configuration in `settings.json`, `ep_align` will be just installed and `ep_ldapauth` will be uninstalled.
+
+
+```puppet
+class { 'etherpad':
+  ensure               => 'present',
+  database_type        => 'mysql',
+  database_name        => 'etherpad',
+  database_user        => 'etherpad',
+  database_password    => '37h3rp4d',
+  plugins_list         => {
+    ep_button_link => true,
+    ep_align       => undef,
+    ep_mypads      => true,
+  },
+  mypads               => {
+    searchBase      =>  'cn=users,cn=accounts,dc=example,dc=com',
+    url             =>  'ldaps://ipa.example.com:636',
+    bindDN          =>  'uid=binduser,cn=sysaccounts,cn=etc,dc=example,dc=com',
+    bindCredentials =>  'bindpassword',
+    searchFilter    =>  '(memberOf=cn=etherpad_users,cn=groups,cn=accounts,dc=example,dc=com)'
+  },
+  ep_local_admin_login => 'my_ep_adminuser',
+  ep_local_admin_pwd   => 'my_ep_adminsecret',
+}
+```
+
+In this case `ep_button_link` and `ep_mypads` will be installed with some configurations in `settings.json`, `ep_align` will be just installed without configuration.
 
 #### button_link
 

--- a/manifests/plugins/ep_mypads.pp
+++ b/manifests/plugins/ep_mypads.pp
@@ -1,27 +1,26 @@
 class etherpad::plugins::ep_mypads {
-  assert_private() etherpad::plugins::common { 'ep_mypads' :
-  }
-  require Class[etherpad::plugins::ep_ldapauth]
+
+  assert_private()
+
   $default_mypads_options = {
-    url                    => $etherpad::plugins::ep_ldapauth::_real_ldapauth_options[url],
-    bindDN                 => $etherpad::plugins::ep_ldapauth::_real_ldapauth_options[searchDN],
-    bindCredentials        => $etherpad::plugins::ep_ldapauth::_real_ldapauth_options[searchPWD],
-    searchBase             => $etherpad::plugins::ep_ldapauth::_real_ldapauth_options[groupSearchBase],
-    searchFilter           => $etherpad::plugins::ep_ldapauth::_real_ldapauth_options[accountBase],
-    tlsOptions             => {
-        rejectUnauthorized => false,
+    searchFilter => '(uid={{username}})',
+    tlsOptions   => {
+      rejectUnauthorized => false,
     },
-    properties    =>  {
-        login     => 'uid',
-        email     => 'mail',
-        firstname => 'givenName',
-        lastname  => 'sn',
+    properties   => {
+      login     => 'uid',
+      email     => 'mail',
+      firstname => 'givenName',
+      lastname  => 'sn',
     },
-    defaultLang => 'fr',
+    defaultLang  => 'fr',
   }
-  etherpad::plugins::common { 'ldapauth-fork' :
+
+  $_real_mypads_options = $default_mypads_options + $etherpad::mypads
+
+  etherpad::plugins::common { 'ep_mypads' :
   }
-  $_real_mypads_options = merge($default_mypads_options, $etherpad::mypads)
+
   concat::fragment { 'ep_mypads':
     target  => "${etherpad::root_dir}/settings.json",
     content => epp("${module_name}/plugins/ep_mypads.epp"),

--- a/spec/classes/etherpad_spec.rb
+++ b/spec/classes/etherpad_spec.rb
@@ -105,12 +105,11 @@ describe 'etherpad' do
           facts
         end
 
-        context 'etherpad class with ep_ldapauth and ep_mypads set' do
+        context 'etherpad class with ep_ldapauth set' do
           let(:params) do
             {
               plugins_list: {
-                'ep_ldapauth' => true,
-                'ep_mypads' => true
+                'ep_ldapauth' => true
               },
               ldapauth: {
                 'url'                => 'ldap://ldap.foobar.com',
@@ -125,58 +124,25 @@ describe 'etherpad' do
           it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r{^\s*"url": "ldap:\/\/ldap.foobar.com",$}) }
           it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r{^\s*"accountBase": "o=staff,o=foo,dc=bar,dc=com",$}) }
           it { is_expected.to contain_concat_fragment('ep_ldapauth').with_content(%r{^\s*"groupAttributeIsDN": false,$}) }
-          it { is_expected.to contain_concat_fragment('ep_mypads').with_content(%r|^\s*"ep_mypads": {$|) }
-          it { is_expected.to contain_concat_fragment('ep_mypads').with_content(%r{^\s*"url": "ldap:\/\/ldap.foobar.com",$}) }
-          it { is_expected.to contain_concat_fragment('ep_mypads').with_content(%r{^\s*"searchFilter": "o=staff,o=foo,dc=bar,dc=com",$}) }
           it { is_expected.to contain_concat_fragment('settings-second.json.epp').without_content(%r{test_user}) }
         end
-      end
-    end
-  end
 
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts) do
-          facts
-        end
-
-        context 'etherpad class with only ep_mypads set' do
-          let(:params) do
-            {
-              plugins_list: {
-                'ep_mypads' => true
-              },
-              ep_local_admin_login: 'test-admin'
-            }
-          end
-
-          it { is_expected.to compile.and_raise_error(%r{You are using the default LDAP configuration}) }
-        end
-      end
-    end
-  end
-
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts) do
-          facts
-        end
-
-        context 'etherpad class with ep_mypads plugin and etherpad::mypads set' do
+        context 'etherpad class with ep_mypads set' do
           let(:params) do
             {
               plugins_list: {
                 'ep_mypads' => true
               },
               mypads: {
-                'url' => 'ldap://ldap.my-example.com'
+                'url'        => 'ldap://ldap.foobar.com',
+                'searchBase' => 'o=staff,o=foo,dc=bar,dc=com'
               }
             }
           end
 
-          it { is_expected.to compile.and_raise_error(%r{You are using the default LDAP configuration}) }
+          it { is_expected.to contain_concat_fragment('ep_mypads').with_content(%r|^\s*"ep_mypads": {$|) }
+          it { is_expected.to contain_concat_fragment('ep_mypads').with_content(%r{^\s*"url": "ldap:\/\/ldap.foobar.com",$}) }
+          it { is_expected.to contain_concat_fragment('ep_mypads').with_content(%r{^\s*"searchBase": "o=staff,o=foo,dc=bar,dc=com"$}) }
         end
       end
     end

--- a/templates/plugins/ep_mypads.epp
+++ b/templates/plugins/ep_mypads.epp
@@ -1,3 +1,11 @@
 // Mypads
 "ep_mypads": {
 "ldap" : <%= to_json_pretty($etherpad::plugins::ep_mypads::_real_mypads_options) %> },
+
+/*When LDAP is configured, you add one Etherpad administrator. To see more, read the documentation.*/
+"users": {
+  "<%= $etherpad::ep_local_admin_login -%>": {
+    "password": "<%= $etherpad::ep_local_admin_pwd -%>",
+    "is_admin": true
+  }
+},

--- a/types/mypads.pp
+++ b/types/mypads.pp
@@ -3,16 +3,11 @@ type Etherpad::Mypads = Struct[
   {
     Optional['url']             => String,
     Optional['bindDN']          => String,
-    Optional['bindCredentials'] => String,
+    Optional['bindCredentials'] => String[1],
     Optional['searchBase']      => String,
     Optional['searchFilter']    => String,
     Optional['tlsOptions']      => Boolean,
     Optional['properties']      => Hash[String, String],
-    Optional['login']           => String,
-    Optional['email']           => String,
-    Optional['firstname']       => String,
-    Optional['lastname']        => String,
     Optional['defaultLang']     => String,
-    Optional['users']           => Hash[String, Variant[String, Boolean]],
   }
 ]


### PR DESCRIPTION

#### Pull Request (PR) description

The helper about plugin `ep_mypads` uses the plugin `ep_ldapauth` settings.

But this is a bug. 

When the plugin `ep_mypads` is installed, it install the npm module `ldapauth-fork` and use it to bind with ldap server.
