### PR TITLE
fix datatype for tlsOptions

### DIFF
--- a/types/mypads.pp
+++ b/types/mypads.pp
@@ -6,7 +6,7 @@ type Etherpad::Mypads = Struct[
     Optional['bindCredentials'] => String[1],
     Optional['searchBase']      => String,
     Optional['searchFilter']    => String,
-    Optional['tlsOptions']      => Boolean,
+    Optional['tlsOptions']      => Hash,
     Optional['properties']      => Hash[String, String],
     Optional['defaultLang']     => String,
   }


### PR DESCRIPTION

#### Pull Request (PR) description

Accordingly to doc [1] `tlsOptions` is not a `Boolean` but `Hash`

[1] https://framagit.org/framasoft/Etherpad/ep_mypads/wikis/use-ldap-authentication

