### PR TITLE
enable production mode

### DIFF
--- a/spec/acceptance/etherpad_spec.rb
+++ b/spec/acceptance/etherpad_spec.rb
@@ -11,9 +11,9 @@ describe 'etherpad' do
           database_user     => 'epuserdb',
           database_password => 'secretdb',
           root_dir          => '/var/etherpad.foo.org',
-	  user              => 'ep',
-	  port              => 8000,
-	  pad_title         => 'the foo organisation',
+          user              => 'ep',
+          port              => 8000,
+          pad_title         => 'the foo organisation',
           users             => {
             admin => {
               password => 's3cr3t',
@@ -48,6 +48,10 @@ describe 'etherpad' do
 
     describe command('curl -L http://localhost:8000') do
       its(:stdout) { is_expected.to match %r{.*the foo organisation.*} }
+    end
+
+    describe command('systemctl status etherpad') do
+      its(:stdout) { is_expected.not_to match %r{.*Etherpad is running in Development mode.*} }
     end
   end
 end

--- a/templates/service/systemd.epp
+++ b/templates/service/systemd.epp
@@ -6,6 +6,7 @@ Requires=network.target
 [Service]
 User=<%= $etherpad::user %>
 Group=<%= $etherpad::group %>
+Environment=NODE_ENV=production
 
 WorkingDirectory=<%= $etherpad::root_dir %>
 ExecStart=<%= $etherpad::root_dir -%>/bin/run.sh


### PR DESCRIPTION

#### Pull Request (PR) description
When etherpad starts, it is displayed :
`Etherpad is running in Development mode.  This mode is slower for users and less secure`

#### This Pull Request (PR) fixes the following issues

