### PR TITLE
Fix ensure pattern to support version numbers with more than one digit

### DIFF
--- a/types/ensure.pp
+++ b/types/ensure.pp
@@ -1,1 +1,1 @@
-type Etherpad::Ensure = Variant[Enum['present', 'latest', 'absent'], Pattern[/\A\d\.\d\.\d\Z/, /\A[a-fA-F0-9]{6,40}\Z/]]
+type Etherpad::Ensure = Variant[Enum['present', 'latest', 'absent'], Pattern[/\A\d+\.\d+\.\d+\Z/, /\A[a-fA-F0-9]{6,40}\Z/]]


### PR DESCRIPTION
#### Pull Request (PR) description
This fixes the pattern used for the ensure parameter.
At the moment only versions with a single digit at each position are allowed. The most recent version of Etherpad is `1.8.17` and Puppet will fail with `Class[Etherpad]: parameter 'ensure' expects an Etherpad::Ensure = Variant[Enum['absent', 'latest', 'present'], Pattern[/\A\d\.\d\.\d\Z/, /\A[a-fA-F0-9]{6,40}\Z/]]`. With this PR multiple digits at each position are possible, ensuring future compatibility.

#### This Pull Request (PR) fixes the following issues
n/a
